### PR TITLE
Update peer deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,6 @@
     "typescript": "^4.6.2"
   },
   "peerDependencies": {
-    "cypress": "^9.5.1"
+    "cypress": ">=9.5.1"
   }
 }


### PR DESCRIPTION
allows installing cypress 10.*+ without warnings